### PR TITLE
Registra aliases de tenants

### DIFF
--- a/empresas/apps.py
+++ b/empresas/apps.py
@@ -19,13 +19,13 @@ class EmpresasConfig(AppConfig):
             return
 
         # Para cada empresa, registra o alias tenant_{id}
-    """  for empresa in Empresa.objects.all():
+        for empresa in Empresa.objects.all():
             alias = f"tenant_{empresa.id}"
             dbname = f"multipla_financeiro_tenant_{empresa.id}"
             if alias not in settings.DATABASES:
                 cfg = default_cfg.copy()
                 cfg['NAME'] = dbname
-                settings.DATABASES[alias] = cfg"""
+                settings.DATABASES[alias] = cfg
 
         # Fecha todas as conexões para o Django recarregar os novos aliases
-       # connections.close_all()
+        connections.close_all()


### PR DESCRIPTION
## Summary
- adiciona registro de aliases tenant_<id> no método ready das empresas
- fecha conexões após registrar novos aliases

## Testing
- `pip install -r requirements.txt` (falhou: Could not find a version that satisfies the requirement pandas)
- `python manage.py test empresas -v 2` (falhou: ModuleNotFoundError: No module named 'django')

------
https://chatgpt.com/codex/tasks/task_e_6892222dbd4c832a81cee8e273073bba